### PR TITLE
refactor: remove the request from useEffect in auth context

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "cookie": "^0.6.0",
+    "cookies-next": "^4.2.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
     "framer-motion": "^10.18.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
     "swr": "^2.2.5",
-    "uploadthing": "^6.13.2"
+    "uploadthing": "^6.13.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -44,15 +44,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // ! useEffect is bad
   useEffect(() => {
     const checkUser = async () => {
-      try {
-        if (hasCookie('user')) {
-          const userCookie = getCookie('user') as string; // Casting here because CookieValueTypes = string | undefined
-          const userData = await decodeCookie(userCookie);
-          setUser(userData);
-        }
-
+      if (hasCookie('user')) {
+        const userCookie = getCookie('user') as string; // Casting here because CookieValueTypes = string | undefined
+        const userData = await decodeCookie(userCookie);
+        setUser(userData);
         setIsAuthenticated(true);
-      } catch (error) {
+      } else {
         setUser(null);
         setIsAuthenticated(false);
       }

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -43,7 +43,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     const checkUser = async () => {
       try {
-        const response = await axios.get('/api/auth/user');
+        const response = await axios.get('/api/auth/user'); // ! This is bad since we have to make a request to the server to check if the user is authenticated
         setUser(response.data.data);
         setIsAuthenticated(true);
       } catch (error) {

--- a/src/lib/dbConnect.ts
+++ b/src/lib/dbConnect.ts
@@ -1,7 +1,8 @@
 // https://github.com/vercel/next.js/blob/canary/examples/with-mongodb-mongoose/lib/dbConnect.ts
+import env from '@/utils/env';
 import mongoose from 'mongoose';
 
-const MONGODB_URI = process.env.MONGODB_URI!;
+const MONGODB_URI = env.MONGODB_URI!;
 
 if (!MONGODB_URI) {
   throw new Error('MONGODB_URI not defined');

--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import bcrypt from 'bcryptjs';
 import { serialize } from 'cookie';
 import jwt from 'jsonwebtoken';
@@ -9,7 +10,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export default async function handler(request: NextApiRequest, response: NextApiResponse) {
   await dbConnect();
 
-  const JWT_SECRET = process.env.JWT_SECRET!;
+  const JWT_SECRET = env.JWT_SECRET!;
 
   if (!JWT_SECRET) {
     return response.status(501).json({
@@ -51,7 +52,7 @@ export default async function handler(request: NextApiRequest, response: NextApi
         const cookie = serialize('token', token, {
           httpOnly: true,
           sameSite: 'strict',
-          secure: process.env.NODE_ENV === 'production',
+          secure: env.NODE_ENV === 'production',
           maxAge: 60 * 60 * 24, // 1 day
           path: '/',
         });

--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -1,6 +1,6 @@
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
-import { AuthUser } from '@/types/auth';
+import { AuthUser, MinUserData } from '@/types/auth';
 import env from '@/utils/env';
 import bcrypt from 'bcryptjs';
 import { serialize } from 'cookie';
@@ -9,15 +9,6 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(request: NextApiRequest, response: NextApiResponse) {
   await dbConnect();
-
-  const JWT_SECRET = env.JWT_SECRET!;
-
-  if (!JWT_SECRET) {
-    return response.status(501).json({
-      message: 'JWT_SECRET is undefined',
-      success: false,
-    });
-  }
 
   try {
     const { email, password } = request.body;
@@ -44,19 +35,40 @@ export default async function handler(request: NextApiRequest, response: NextApi
           lastName: user.lastName,
           profileImgUrl: user.profileImgUrl,
         };
-        const token = await jwt.sign(jwtTokenData, JWT_SECRET, {
+
+        const userData: MinUserData = {
+          firstName: user.firstName,
+          lastName: user.lastName,
+          profileImgUrl: user.profileImgUrl,
+        };
+
+        const token = await jwt.sign(jwtTokenData, env.JWT_SECRET, {
           expiresIn: '1d',
           algorithm: 'HS512',
         });
 
-        const cookie = serialize('token', token, {
+        // TODO: Encrypt user data using a different method instead of using JWT??
+        const userToken = await jwt.sign(userData, env.SECRET_KEY, {
+          expiresIn: '1d',
+        });
+
+        const jwtCookie = serialize('token', token, {
           httpOnly: true,
           sameSite: 'strict',
           secure: env.NODE_ENV === 'production',
           maxAge: 60 * 60 * 24, // 1 day
           path: '/',
         });
-        response.setHeader('Set-Cookie', cookie);
+
+        const userCookie = serialize('user', userToken, {
+          httpOnly: false,
+          sameSite: 'strict',
+          secure: env.NODE_ENV === 'production',
+          maxAge: 60 * 60 * 24, // 1 day
+          path: '/',
+        });
+
+        response.setHeader('Set-Cookie', [jwtCookie, userCookie]);
         return response.status(200).json({
           message: 'Signed in successfully',
           success: true,

--- a/src/pages/api/auth/update.ts
+++ b/src/pages/api/auth/update.ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -17,7 +18,7 @@ export default async function handler(request: NextApiRequest, response: NextApi
 
   try {
     const newUserData = request.body;
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const updatedUserData = await User.findByIdAndUpdate({ _id: user.id }, { ...newUserData }, { new: true });
 
     return response.status(201).json({

--- a/src/pages/api/auth/user.ts
+++ b/src/pages/api/auth/user.ts
@@ -17,9 +17,9 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
   }
 
   try {
-    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
+    console.log(env);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const userDataFromDB = await User.findById(user.id).select('-password -updatedAt -createdAt'); // User data from DB excluding password
 
     return response.status(200).json({

--- a/src/pages/api/auth/user.ts
+++ b/src/pages/api/auth/user.ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import User from '@/models/User';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -16,13 +17,13 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
   }
 
   try {
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const userDataFromDB = await User.findById(user.id).select('-password'); // User data from DB excluding password
+    const userDataFromDB = await User.findById(user.id).select('-password -updatedAt -createdAt'); // User data from DB excluding password
 
     return response.status(200).json({
-      data: user,
+      data: userDataFromDB,
       message: 'User retrieved successfully.',
       success: true,
     });

--- a/src/pages/api/blog/create.ts
+++ b/src/pages/api/blog/create.ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import Blog from '@/models/Blog';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -18,7 +19,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
 
   try {
     const blogData = request.body;
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const newBlog = new Blog({
       ...blogData,
       userId: new mongoose.Types.ObjectId(user.id),

--- a/src/pages/api/blog/delete/[pid].ts
+++ b/src/pages/api/blog/delete/[pid].ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import Blog from '@/models/Blog';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -17,7 +18,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
 
   try {
     const blogPostId = request.query.pid;
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const blogPost = await Blog.findById(blogPostId);
 
     // VERIFY ONLY THE USER WHO CREATED THE BLOG POST CAN DELETE IT

--- a/src/pages/api/blog/edit/[pid].ts
+++ b/src/pages/api/blog/edit/[pid].ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import Blog from '@/models/Blog';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -18,7 +19,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
   try {
     const blogPostId = request.query.pid;
     const blogPostData = request.body;
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const existBlogPost = await Blog.findById(blogPostId);
 
     // VERIFY ONLY THE USER WHO CREATED THE BLOG POST CAN UPDATE IT

--- a/src/pages/api/blog/get/[pid].ts
+++ b/src/pages/api/blog/get/[pid].ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import Blog from '@/models/Blog';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -17,7 +18,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
 
   try {
     const blogPostId = request.query.pid;
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const blogPost = await Blog.findById(blogPostId);
 
     if (blogPost === null) {

--- a/src/pages/api/blog/userPosts.ts
+++ b/src/pages/api/blog/userPosts.ts
@@ -1,6 +1,7 @@
 import dbConnect from '@/lib/dbConnect';
 import Blog from '@/models/Blog';
 import { AuthUser } from '@/types/auth';
+import env from '@/utils/env';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -16,7 +17,7 @@ async function handler(request: NextApiRequest, response: NextApiResponse) {
   }
 
   try {
-    const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+    const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
     const posts = await Blog.find({ userId: new mongoose.Types.ObjectId(user.id) });
 
     return response.status(200).json({

--- a/src/server/uploadthing.ts
+++ b/src/server/uploadthing.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { createUploadthing, type FileRouter } from 'uploadthing/next-legacy';
 import { UploadThingError } from 'uploadthing/server';
 import { updateProfilePic } from './mongodb';
+import env from '@/utils/env';
 
 const f = createUploadthing();
 
@@ -22,7 +23,7 @@ export const customFileRouter = {
       }
 
       try {
-        const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+        const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
         return {
           userId: user.id,
         };
@@ -63,7 +64,7 @@ export const customFileRouter = {
       }
 
       try {
-        const user = (await jwt.verify(token, process.env.JWT_SECRET!)) as AuthUser;
+        const user = (await jwt.verify(token, env.JWT_SECRET!)) as AuthUser;
         return {
           userId: user.id,
         };

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -35,3 +35,9 @@ export interface BasicUser {
   firstName: string;
   lastName: string;
 }
+
+export interface MinUserData {
+  firstName: string;
+  lastName: string;
+  profileImgUrl: string;
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,42 @@
+// https://creatures.sh/blog/env-type-safety-and-validation/
+
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.union([z.literal('development'), z.literal('production')]).default('development'),
+  JWT_SECRET: z.string({
+    message: 'JWT_SECRET is required.',
+    required_error: 'JWT_SECRET is required.',
+  }), // ! Zod v3.23.8 does not support JWT verification, wait till v4
+  MONGODB_URI: z
+    .string({
+      description: 'MongoDB connection string.',
+      required_error: 'MONGODB_URI connection is required.',
+    })
+    .url(),
+  MONGODB_USER: z.string({
+    description: 'MongoDB username.',
+    required_error: 'MONGODB username is required.',
+  }),
+  MONGODB_PW: z.string({
+    description: 'MongoDB password.',
+    required_error: 'MONGODB password is required.',
+  }),
+  MONGODB_NAME: z
+    .string({
+      description: 'MongoDB database name.',
+    })
+    .default('quoteGen'),
+  UPLOADTHING_SECRET: z.string({
+    description: 'UPLOADTHING  for uploading files.',
+    required_error: 'UPLOADTHING secret key is required.',
+  }),
+  UPLOADTHING_APP_ID: z.string({
+    description: 'UPLOADTHING app ID.',
+    required_error: 'UPLOADTHING app ID is required.',
+  }),
+});
+
+const env = envSchema.parse(process.env);
+
+export default env;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -5,9 +5,13 @@ import { z } from 'zod';
 const envSchema = z.object({
   NODE_ENV: z.union([z.literal('development'), z.literal('production')]).default('development'),
   JWT_SECRET: z.string({
-    message: 'JWT_SECRET is required.',
+    message: 'JWT Secret key to encode and decode JWT token.',
     required_error: 'JWT_SECRET is required.',
   }), // ! Zod v3.23.8 does not support JWT verification, wait till v4
+  SECRET_KEY: z.string({
+    description: 'A different secret key for encode and decode JWT data user data',
+    required_error: 'SECRET_KEY is required.',
+  }),
   MONGODB_URI: z
     .string({
       description: 'MongoDB connection string.',

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -18,19 +18,6 @@ const envSchema = z.object({
       required_error: 'MONGODB_URI connection is required.',
     })
     .url(),
-  MONGODB_USER: z.string({
-    description: 'MongoDB username.',
-    required_error: 'MONGODB username is required.',
-  }),
-  MONGODB_PW: z.string({
-    description: 'MongoDB password.',
-    required_error: 'MONGODB password is required.',
-  }),
-  MONGODB_NAME: z
-    .string({
-      description: 'MongoDB database name.',
-    })
-    .default('quoteGen'),
   UPLOADTHING_SECRET: z.string({
     description: 'UPLOADTHING  for uploading files.',
     required_error: 'UPLOADTHING secret key is required.',

--- a/src/utils/userCookie.ts
+++ b/src/utils/userCookie.ts
@@ -1,0 +1,12 @@
+import { MinUserData } from '@/types/auth';
+import jwt from 'jsonwebtoken';
+
+export async function decodeCookie(value: string) {
+  console.log(value);
+
+  const userData = (await jwt.decode(value, {
+    json: true,
+  })) as MinUserData;
+
+  return userData;
+}

--- a/src/utils/userCookie.ts
+++ b/src/utils/userCookie.ts
@@ -2,8 +2,6 @@ import { MinUserData } from '@/types/auth';
 import jwt from 'jsonwebtoken';
 
 export async function decodeCookie(value: string) {
-  console.log(value);
-
   const userData = (await jwt.decode(value, {
     json: true,
   })) as MinUserData;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5396,3 +5396,8 @@ yocto-queue@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
   integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
+
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,6 +2205,14 @@ cookie@^0.6.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
   integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
 
+cookies-next@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.2.1.tgz#a0c2942afee16f1ffc2bc05a003c7c0cf32deda5"
+  integrity sha512-qsjtZ8TLlxCSX2JphMQNhkm3V3zIMQ05WrLkBKBwu50npBbBfiZWIdmSMzBGcdGKfMK19E0PIitTfRFAdMGHXg==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.6.0"
+
 copy-to-clipboard@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"


### PR DESCRIPTION
The intention is to remove the need of having to make request to the backend to determine whether the user is authenticated or not. Replace with `non-httpOnly` cookie called `user` to be check in the useEffect hook.

Might need a separate encrypt and decrypt method rather using the same `encode/decode` functions from `jsonwebtoken` module for the user cookie